### PR TITLE
Let's unregister all listeners and register again

### DIFF
--- a/src/main/java/pl/plajer/murdermystery/Main.java
+++ b/src/main/java/pl/plajer/murdermystery/Main.java
@@ -33,6 +33,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.potion.PotionEffect;
 
@@ -193,6 +194,9 @@ public class Main extends JavaPlugin {
       arena.teleportAllToEndLocation();
       arena.cleanUpArena();
     }
+
+    HandlerList.unregisterAll(this);
+
     Debugger.debug(Level.INFO, "System disable finished took {0}ms", System.currentTimeMillis() - start);
   }
 
@@ -349,6 +353,20 @@ public class Main extends JavaPlugin {
 
   public UserManager getUserManager() {
     return userManager;
+  }
+
+  public void loadListeners() {
+    HandlerList.unregisterAll(this);
+
+    new ArenaEvents(this);
+    new SpectatorEvents(this);
+    new QuitEvent(this);
+    new JoinEvent(this);
+    new ChatEvents(this);
+    new Events(this);
+    new LobbyEvent(this);
+    new SpectatorItemEvents(this);
+    new SpecialBlockEvents(this);
   }
 
   private void saveAllUserStatistics() {

--- a/src/main/java/pl/plajer/murdermystery/commands/arguments/admin/arena/ReloadArgument.java
+++ b/src/main/java/pl/plajer/murdermystery/commands/arguments/admin/arena/ReloadArgument.java
@@ -87,6 +87,9 @@ public class ReloadArgument {
           Debugger.debug(Level.INFO, "[Reloader] Instance {0} stopped took {1}ms", arena.getId(), System.currentTimeMillis() - stopTime);
         }
         ArenaRegistry.registerArenas();
+
+        registry.getPlugin().loadListeners();
+
         sender.sendMessage(ChatManager.PLUGIN_PREFIX + ChatManager.colorMessage("Commands.Admin-Commands.Success-Reload"));
         Debugger.debug(Level.INFO, "[Reloader] Finished reloading took {0}ms", System.currentTimeMillis() - start);
       }


### PR DESCRIPTION
This fixes some memory leak issues with Bukkit events.
```java
HandlerList.unregisterAll(this);
```
**This only unregisters the Bukkit events in this plugin** and register again to prevent memory leak issue some in some users.

If still have some Bukkit API event classes in this plugin, I'll add it.