### PR TITLE
3 little fixes

### DIFF
--- a/src/main/java/pl/plajer/murdermystery/arena/ArenaRegistry.java
+++ b/src/main/java/pl/plajer/murdermystery/arena/ArenaRegistry.java
@@ -140,8 +140,8 @@ public class ArenaRegistry {
       arena.setMinimumPlayers(config.getInt(s + "minimumplayers", 2));
       arena.setMaximumPlayers(config.getInt(s + "maximumplayers", 4));
       arena.setMapName(config.getString(s + "mapname", "none"));
-      arena.setMurderers(plugin.getConfig().getInt(s + "playerpermurderer", 5));
-      arena.setDetectives(plugin.getConfig().getInt(s + "playerperdetective", 7));
+      arena.setMurderers(config.getInt(s + "playerpermurderer", 5));
+      arena.setDetectives(config.getInt(s + "playerperdetective", 7));
       List<Location> playerSpawnPoints = new ArrayList<>();
       for (String loc : config.getStringList(s + "playerspawnpoints")) {
         playerSpawnPoints.add(LocationSerializer.getLocation(loc));

--- a/src/main/java/pl/plajer/murdermystery/events/JoinEvent.java
+++ b/src/main/java/pl/plajer/murdermystery/events/JoinEvent.java
@@ -62,16 +62,16 @@ public class JoinEvent implements Listener {
 
   @EventHandler
   public void onJoin(PlayerJoinEvent event) {
-    if (plugin.getConfigPreferences().getOption(ConfigPreferences.Option.BUNGEE_ENABLED)) {
+    if (!plugin.getConfigPreferences().getOption(ConfigPreferences.Option.BUNGEE_ENABLED)) {
+      for (Player player : plugin.getServer().getOnlinePlayers()) {
+        if (ArenaRegistry.getArena(player) == null) {
+          continue;
+        }
+        player.hidePlayer(event.getPlayer());
+        event.getPlayer().hidePlayer(player);
+      }  
+    } else {
       ArenaRegistry.getArenas().get(0).teleportToLobby(event.getPlayer());
-      return;
-    }
-    for (Player player : plugin.getServer().getOnlinePlayers()) {
-      if (ArenaRegistry.getArena(player) == null) {
-        continue;
-      }
-      player.hidePlayer(event.getPlayer());
-      event.getPlayer().hidePlayer(player);
     }
     User user = plugin.getUserManager().getUser(event.getPlayer());
     for (StatsStorage.StatisticType stat : StatsStorage.StatisticType.values()) {

--- a/src/main/java/pl/plajer/murdermystery/user/data/MysqlManager.java
+++ b/src/main/java/pl/plajer/murdermystery/user/data/MysqlManager.java
@@ -49,7 +49,7 @@ public class MysqlManager implements UserDatabase {
       try (Connection connection = database.getConnection()) {
         Statement statement = connection.createStatement();
         statement.executeUpdate("CREATE TABLE IF NOT EXISTS `playerstats` (\n"
-          + "  `UUID` text NOT NULL,\n"
+          + "  `UUID` text NOT NULL UNIQUE,\n"
           + "  `name` text NOT NULL,\n"
           + "  `kills` int(11) NOT NULL DEFAULT '0',\n"
           + "  `deaths` int(11) NOT NULL DEFAULT '0',\n"


### PR DESCRIPTION
My config is : Bungee + Mysql

Modification on `JoinEvent.java` :
At the first start with this plugin nobody has stats and when in 'bungeecoord mode' the plugin dosen't call `loadStatistic` on player join, and so in the `run` of the `Arena` BukkitRunnable the `totalMurderer` was at 0 :
![image](https://user-images.githubusercontent.com/1301995/71775414-f6228c00-2f80-11ea-9666-3802abb869b1.png)

Modification on `MysqlManager.java`  :
I don't know why but the plugin can create many entries in DB when player stats is added : 
![image](https://user-images.githubusercontent.com/1301995/71775484-a6909000-2f81-11ea-96d5-427d3bd8998b.png)
I didn't search why, but adding a little unique constraint solve the problem (The plugin does not crash, it just show some warning because of the constraint violation)

Modification on `ArenaRegistry.java ` :
This seem more logcal ? Or i'm missing a reason to get theses two values from the main config file.

Thanks for this plugin !