### PR TITLE
Use primary key and and proper data types in DB schema

### DIFF
--- a/src/main/java/pl/plajer/murdermystery/user/data/MysqlManager.java
+++ b/src/main/java/pl/plajer/murdermystery/user/data/MysqlManager.java
@@ -49,8 +49,8 @@ public class MysqlManager implements UserDatabase {
       try (Connection connection = database.getConnection()) {
         Statement statement = connection.createStatement();
         statement.executeUpdate("CREATE TABLE IF NOT EXISTS `playerstats` (\n"
-          + "  `UUID` text NOT NULL,\n"
-          + "  `name` text NOT NULL,\n"
+          + "  `UUID` char(36) NOT NULL PRIMARY KEY,\n"
+          + "  `name` varchar(16) NOT NULL,\n"
           + "  `kills` int(11) NOT NULL DEFAULT '0',\n"
           + "  `deaths` int(11) NOT NULL DEFAULT '0',\n"
           + "  `highestscore` int(11) NOT NULL DEFAULT '0',\n"


### PR DESCRIPTION
This makes changes the table schema in the DB:
- Makes the `UUID` field a primary key, so it's impossible to have duplicates.
- Use more appropriate data types (char/varchar) to better suit the data in the table.

Currently untested because I'm unable to build the plugin due to missing dependencies.

This won't properly fix the issue, it will just prevent the duplicates, but will cause SQL exception errors. The real fix to this is to change the logic inside `PlayerJoinEvent` and `loadStatistic` so that all statistics are loaded in a single SQL query/task. The duplicate insertion is happening because of concurrent tasks checking/inserting records independently.

If I can get the project to build properly, I'll restructure the stat loading to work that way.