### PR TITLE
Refactor how statistics DB handling works.

### DIFF
--- a/src/main/java/pl/plajer/murdermystery/events/JoinEvent.java
+++ b/src/main/java/pl/plajer/murdermystery/events/JoinEvent.java
@@ -74,9 +74,7 @@ public class JoinEvent implements Listener {
       event.getPlayer().hidePlayer(player);
     }
     User user = plugin.getUserManager().getUser(event.getPlayer());
-    for (StatsStorage.StatisticType stat : StatsStorage.StatisticType.values()) {
-      plugin.getUserManager().loadStatistic(user, stat);
-    }
+    plugin.getUserManager().loadStatistics(user);
     //load player inventory in case of server crash, file is deleted once loaded so if file was already
     //deleted player won't receive his backup, in case of crash he will get it back
     if (plugin.getConfigPreferences().getOption(ConfigPreferences.Option.INVENTORY_MANAGER_ENABLED)) {

--- a/src/main/java/pl/plajer/murdermystery/user/UserManager.java
+++ b/src/main/java/pl/plajer/murdermystery/user/UserManager.java
@@ -56,9 +56,7 @@ public class UserManager {
   private void loadStatsForPlayersOnline() {
     for (Player player : Bukkit.getServer().getOnlinePlayers()) {
       User user = getUser(player);
-      for (StatsStorage.StatisticType stat : StatsStorage.StatisticType.values()) {
-        loadStatistic(user, stat);
-      }
+      loadStatistics(user);
     }
   }
 
@@ -91,11 +89,8 @@ public class UserManager {
     database.saveStatistic(user, stat);
   }
 
-  public void loadStatistic(User user, StatsStorage.StatisticType stat) {
-    if (!stat.isPersistent()) {
-      return;
-    }
-    database.loadStatistic(user, stat);
+  public void loadStatistics(User user) {
+    database.loadStatistics(user);
     //apply after load to override
     fixContirbutionStatistics(user);
   }

--- a/src/main/java/pl/plajer/murdermystery/user/data/FileStats.java
+++ b/src/main/java/pl/plajer/murdermystery/user/data/FileStats.java
@@ -47,8 +47,10 @@ public class FileStats implements UserDatabase {
   }
 
   @Override
-  public void loadStatistic(User user, StatsStorage.StatisticType stat) {
-    user.setStat(stat, config.getInt(user.getPlayer().getUniqueId().toString() + "." + stat.getName(), 0));
+  public void loadStatistics(User user) {
+    for (StatsStorage.StatisticType stat : StatsStorage.StatisticType.values()) {
+      user.setStat(stat, config.getInt(user.getPlayer().getUniqueId().toString() + "." + stat.getName(), 0));
+    }
   }
 
 }

--- a/src/main/java/pl/plajer/murdermystery/user/data/MysqlManager.java
+++ b/src/main/java/pl/plajer/murdermystery/user/data/MysqlManager.java
@@ -49,8 +49,8 @@ public class MysqlManager implements UserDatabase {
       try (Connection connection = database.getConnection()) {
         Statement statement = connection.createStatement();
         statement.executeUpdate("CREATE TABLE IF NOT EXISTS `playerstats` (\n"
-          + "  `UUID` text NOT NULL,\n"
-          + "  `name` text NOT NULL,\n"
+          + "  `UUID` char(36) NOT NULL PRIMARY KEY,\n"
+          + "  `name` varchar(32) NOT NULL,\n"
           + "  `kills` int(11) NOT NULL DEFAULT '0',\n"
           + "  `deaths` int(11) NOT NULL DEFAULT '0',\n"
           + "  `highestscore` int(11) NOT NULL DEFAULT '0',\n"
@@ -71,34 +71,36 @@ public class MysqlManager implements UserDatabase {
 
   @Override
   public void saveStatistic(User user, StatsStorage.StatisticType stat) {
-    Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> database.executeUpdate("UPDATE playerstats SET " + stat.getName() + "=" + user.getStat(stat) + " WHERE UUID='" + user.getPlayer().getUniqueId().toString() + "';"));
+    Bukkit.getScheduler().runTaskAsynchronously(plugin, () ->
+      database.executeUpdate("UPDATE playerstats SET " + stat.getName() + "=" + user.getStat(stat) + " WHERE UUID='" + user.getPlayer().getUniqueId().toString() + "';"));
   }
 
   @Override
-  public void loadStatistic(User user, StatsStorage.StatisticType stat) {
+  public void loadStatistics(User user) {
     Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+      String uuid = user.getPlayer().getUniqueId().toString();
       try (Connection connection = database.getConnection()) {
         Statement statement = connection.createStatement();
-        //insert into the database
-        if (!statement.executeQuery("SELECT UUID from playerstats WHERE UUID='" + user.getPlayer().getUniqueId().toString() + "'").next()) {
-          insertPlayer(user.getPlayer());
+        ResultSet rs = statement.executeQuery("SELECT * from playerstats WHERE UUID='" + uuid + "'");
+        if (rs.next()) {
+          //player already exists - get the stats
+          for (StatsStorage.StatisticType stat : StatsStorage.StatisticType.values()) {
+            if (!stat.isPersistent()) continue;;
+            int val = rs.getInt(stat.getName());
+            user.setStat(stat, val);
+          }
+        } else {
+          //player doesn't exist - make a new record
+          statement.executeUpdate("INSERT INTO playerstats (UUID,name) VALUES ('" + uuid + "','" + user.getPlayer().getName() + "')");
+          for (StatsStorage.StatisticType stat : StatsStorage.StatisticType.values()) {
+            if (!stat.isPersistent()) continue;;
+            user.setStat(stat, 0);
+          }
         }
-
-        ResultSet set = statement.executeQuery("SELECT " + stat.getName() + " FROM playerstats WHERE UUID='" + user.getPlayer().getUniqueId().toString() + "'");
-        if (!set.next()) {
-          user.setStat(stat, 0);
-          return;
-        }
-        user.setStat(stat, set.getInt(1));
       } catch (SQLException e) {
         e.printStackTrace();
-        user.setStat(stat, 0);
       }
     });
-  }
-
-  private void insertPlayer(Player player) {
-    database.executeUpdate("INSERT INTO playerstats (UUID,name) VALUES ('" + player.getUniqueId().toString() + "','" + player.getName() + "')");
   }
 
   public MysqlDatabase getDatabase() {

--- a/src/main/java/pl/plajer/murdermystery/user/data/UserDatabase.java
+++ b/src/main/java/pl/plajer/murdermystery/user/data/UserDatabase.java
@@ -40,8 +40,7 @@ public interface UserDatabase {
    * Loads player statistic from yaml or MySQL storage based on user choice
    *
    * @param user user to load statistic for
-   * @param stat type of stat to load from storage
    */
-  void loadStatistic(User user, StatsStorage.StatisticType stat);
+  void loadStatistics(User user);
 
 }


### PR DESCRIPTION
Due to all the MySQL data issues and inefficient queries, I decided to re-write the DB handling for statistics. This change does the following:

- Fix duplicate playerstats entries in the DB by loading all stats for a player in a single task.
- Refactor how stat loading works to be more efficient by using a single query and function call to load stats.

This has been tested and seems to be working as expected. It should continue working for existing users, but it would be best to `DROP TABLE` before upgrading to get the new schema. I didn't bother making a schema upgrade, since the existing data is useless for all users anyway.