### PR TITLE
Implementing some more Events for the Developer API

### DIFF
--- a/src/main/java/plugily/projects/murdermystery/api/events/game/MurderGameBuyEvent.java
+++ b/src/main/java/plugily/projects/murdermystery/api/events/game/MurderGameBuyEvent.java
@@ -18,36 +18,26 @@
 
 package plugily.projects.murdermystery.api.events.game;
 
-import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.Nullable;
 import plugily.projects.minigamesbox.api.events.PlugilyEvent;
 import plugily.projects.murdermystery.arena.Arena;
+import plugily.projects.murdermystery.arena.special.SpecialBlock;
 
-/**
- * @author Tigerpanzer_02
- * <p>
- * Created at 15.04.2022
- */
-public class MurderGameCorpseSpawnEvent extends PlugilyEvent implements Cancellable {
+public class MurderGameBuyEvent extends PlugilyEvent implements Cancellable {
 
   private static final HandlerList HANDLERS = new HandlerList();
   private boolean isCancelled = false;
   private final Player player;
-  private final Location location;
-  private final Player killer;
+  private final SpecialBlock.SpecialBlockType specialBlockType;
+  private final int cost;
 
-  public MurderGameCorpseSpawnEvent(Arena arena, Player player, Location location) {
-    this(arena, player, location, null);
-  }
-
-  public MurderGameCorpseSpawnEvent(Arena arena, Player player, Location location, @Nullable Player killer) {
+  public MurderGameBuyEvent(Arena arena, Player player, SpecialBlock.SpecialBlockType specialBlockType, int cost) {
     super(arena);
     this.player = player;
-    this.location = location;
-    this.killer = killer;
+    this.specialBlockType = specialBlockType;
+    this.cost = cost;
   }
 
   public static HandlerList getHandlerList() {
@@ -73,13 +63,11 @@ public class MurderGameCorpseSpawnEvent extends PlugilyEvent implements Cancella
     return player;
   }
 
-  public Location getLocation() {
-    return location;
+  public SpecialBlock.SpecialBlockType getSpecialBlockType() {
+    return specialBlockType;
   }
 
-  @Nullable
-  public Player getKiller() {
-    return killer;
+  public int getCost() {
+    return cost;
   }
-
 }

--- a/src/main/java/plugily/projects/murdermystery/api/events/game/MurderGameEndEvent.java
+++ b/src/main/java/plugily/projects/murdermystery/api/events/game/MurderGameEndEvent.java
@@ -18,36 +18,23 @@
 
 package plugily.projects.murdermystery.api.events.game;
 
-import org.bukkit.Location;
 import org.bukkit.entity.Player;
-import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.Nullable;
 import plugily.projects.minigamesbox.api.events.PlugilyEvent;
 import plugily.projects.murdermystery.arena.Arena;
 
-/**
- * @author Tigerpanzer_02
- * <p>
- * Created at 15.04.2022
- */
-public class MurderGameCorpseSpawnEvent extends PlugilyEvent implements Cancellable {
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class MurderGameEndEvent extends PlugilyEvent {
 
   private static final HandlerList HANDLERS = new HandlerList();
-  private boolean isCancelled = false;
-  private final Player player;
-  private final Location location;
-  private final Player killer;
+  private final List<Player> players;
 
-  public MurderGameCorpseSpawnEvent(Arena arena, Player player, Location location) {
-    this(arena, player, location, null);
-  }
-
-  public MurderGameCorpseSpawnEvent(Arena arena, Player player, Location location, @Nullable Player killer) {
+  public MurderGameEndEvent(Arena arena, List<Player> players) {
     super(arena);
-    this.player = player;
-    this.location = location;
-    this.killer = killer;
+    this.players = Collections.unmodifiableList(new ArrayList<>(players));
   }
 
   public static HandlerList getHandlerList() {
@@ -59,27 +46,7 @@ public class MurderGameCorpseSpawnEvent extends PlugilyEvent implements Cancella
     return HANDLERS;
   }
 
-  @Override
-  public boolean isCancelled() {
-    return isCancelled;
+  public List<Player> getPlayers() {
+    return players;
   }
-
-  @Override
-  public void setCancelled(boolean cancelled) {
-    isCancelled = cancelled;
-  }
-
-  public Player getPlayer() {
-    return player;
-  }
-
-  public Location getLocation() {
-    return location;
-  }
-
-  @Nullable
-  public Player getKiller() {
-    return killer;
-  }
-
 }

--- a/src/main/java/plugily/projects/murdermystery/api/events/game/MurderGameGetBowEvent.java
+++ b/src/main/java/plugily/projects/murdermystery/api/events/game/MurderGameGetBowEvent.java
@@ -18,36 +18,21 @@
 
 package plugily.projects.murdermystery.api.events.game;
 
-import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.Nullable;
 import plugily.projects.minigamesbox.api.events.PlugilyEvent;
 import plugily.projects.murdermystery.arena.Arena;
 
-/**
- * @author Tigerpanzer_02
- * <p>
- * Created at 15.04.2022
- */
-public class MurderGameCorpseSpawnEvent extends PlugilyEvent implements Cancellable {
+public class MurderGameGetBowEvent extends PlugilyEvent implements Cancellable {
 
   private static final HandlerList HANDLERS = new HandlerList();
   private boolean isCancelled = false;
   private final Player player;
-  private final Location location;
-  private final Player killer;
 
-  public MurderGameCorpseSpawnEvent(Arena arena, Player player, Location location) {
-    this(arena, player, location, null);
-  }
-
-  public MurderGameCorpseSpawnEvent(Arena arena, Player player, Location location, @Nullable Player killer) {
+  public MurderGameGetBowEvent(Arena arena, Player player) {
     super(arena);
     this.player = player;
-    this.location = location;
-    this.killer = killer;
   }
 
   public static HandlerList getHandlerList() {
@@ -72,14 +57,4 @@ public class MurderGameCorpseSpawnEvent extends PlugilyEvent implements Cancella
   public Player getPlayer() {
     return player;
   }
-
-  public Location getLocation() {
-    return location;
-  }
-
-  @Nullable
-  public Player getKiller() {
-    return killer;
-  }
-
 }

--- a/src/main/java/plugily/projects/murdermystery/api/events/game/MurderGameGoldPickupEvent.java
+++ b/src/main/java/plugily/projects/murdermystery/api/events/game/MurderGameGoldPickupEvent.java
@@ -18,36 +18,23 @@
 
 package plugily.projects.murdermystery.api.events.game;
 
-import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.Nullable;
 import plugily.projects.minigamesbox.api.events.PlugilyEvent;
 import plugily.projects.murdermystery.arena.Arena;
 
-/**
- * @author Tigerpanzer_02
- * <p>
- * Created at 15.04.2022
- */
-public class MurderGameCorpseSpawnEvent extends PlugilyEvent implements Cancellable {
+public class MurderGameGoldPickupEvent extends PlugilyEvent implements Cancellable {
 
   private static final HandlerList HANDLERS = new HandlerList();
   private boolean isCancelled = false;
   private final Player player;
-  private final Location location;
-  private final Player killer;
+  private final int amount;
 
-  public MurderGameCorpseSpawnEvent(Arena arena, Player player, Location location) {
-    this(arena, player, location, null);
-  }
-
-  public MurderGameCorpseSpawnEvent(Arena arena, Player player, Location location, @Nullable Player killer) {
+  public MurderGameGoldPickupEvent(Arena arena, Player player, int amount) {
     super(arena);
     this.player = player;
-    this.location = location;
-    this.killer = killer;
+    this.amount = amount;
   }
 
   public static HandlerList getHandlerList() {
@@ -73,13 +60,7 @@ public class MurderGameCorpseSpawnEvent extends PlugilyEvent implements Cancella
     return player;
   }
 
-  public Location getLocation() {
-    return location;
+  public int getAmount() {
+    return amount;
   }
-
-  @Nullable
-  public Player getKiller() {
-    return killer;
-  }
-
 }

--- a/src/main/java/plugily/projects/murdermystery/api/events/game/MurderGameGoldSpawnEvent.java
+++ b/src/main/java/plugily/projects/murdermystery/api/events/game/MurderGameGoldSpawnEvent.java
@@ -19,35 +19,20 @@
 package plugily.projects.murdermystery.api.events.game;
 
 import org.bukkit.Location;
-import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.Nullable;
 import plugily.projects.minigamesbox.api.events.PlugilyEvent;
 import plugily.projects.murdermystery.arena.Arena;
 
-/**
- * @author Tigerpanzer_02
- * <p>
- * Created at 15.04.2022
- */
-public class MurderGameCorpseSpawnEvent extends PlugilyEvent implements Cancellable {
+public class MurderGameGoldSpawnEvent extends PlugilyEvent implements Cancellable {
 
   private static final HandlerList HANDLERS = new HandlerList();
   private boolean isCancelled = false;
-  private final Player player;
   private final Location location;
-  private final Player killer;
 
-  public MurderGameCorpseSpawnEvent(Arena arena, Player player, Location location) {
-    this(arena, player, location, null);
-  }
-
-  public MurderGameCorpseSpawnEvent(Arena arena, Player player, Location location, @Nullable Player killer) {
+  public MurderGameGoldSpawnEvent(Arena arena, Location location) {
     super(arena);
-    this.player = player;
     this.location = location;
-    this.killer = killer;
   }
 
   public static HandlerList getHandlerList() {
@@ -69,17 +54,7 @@ public class MurderGameCorpseSpawnEvent extends PlugilyEvent implements Cancella
     isCancelled = cancelled;
   }
 
-  public Player getPlayer() {
-    return player;
-  }
-
   public Location getLocation() {
     return location;
   }
-
-  @Nullable
-  public Player getKiller() {
-    return killer;
-  }
-
 }

--- a/src/main/java/plugily/projects/murdermystery/api/events/game/MurderGamePowerUpPickupEvent.java
+++ b/src/main/java/plugily/projects/murdermystery/api/events/game/MurderGamePowerUpPickupEvent.java
@@ -18,36 +18,24 @@
 
 package plugily.projects.murdermystery.api.events.game;
 
-import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.Nullable;
+import org.bukkit.inventory.ItemStack;
 import plugily.projects.minigamesbox.api.events.PlugilyEvent;
 import plugily.projects.murdermystery.arena.Arena;
 
-/**
- * @author Tigerpanzer_02
- * <p>
- * Created at 15.04.2022
- */
-public class MurderGameCorpseSpawnEvent extends PlugilyEvent implements Cancellable {
+public class MurderGamePowerUpPickupEvent extends PlugilyEvent implements Cancellable {
 
   private static final HandlerList HANDLERS = new HandlerList();
   private boolean isCancelled = false;
   private final Player player;
-  private final Location location;
-  private final Player killer;
+  private final ItemStack powerUpItem;
 
-  public MurderGameCorpseSpawnEvent(Arena arena, Player player, Location location) {
-    this(arena, player, location, null);
-  }
-
-  public MurderGameCorpseSpawnEvent(Arena arena, Player player, Location location, @Nullable Player killer) {
+  public MurderGamePowerUpPickupEvent(Arena arena, Player player, ItemStack powerUpItem) {
     super(arena);
     this.player = player;
-    this.location = location;
-    this.killer = killer;
+    this.powerUpItem = powerUpItem;
   }
 
   public static HandlerList getHandlerList() {
@@ -73,13 +61,7 @@ public class MurderGameCorpseSpawnEvent extends PlugilyEvent implements Cancella
     return player;
   }
 
-  public Location getLocation() {
-    return location;
+  public ItemStack getPowerUpItem() {
+    return powerUpItem;
   }
-
-  @Nullable
-  public Player getKiller() {
-    return killer;
-  }
-
 }

--- a/src/main/java/plugily/projects/murdermystery/api/events/game/MurderGameStartEvent.java
+++ b/src/main/java/plugily/projects/murdermystery/api/events/game/MurderGameStartEvent.java
@@ -18,36 +18,23 @@
 
 package plugily.projects.murdermystery.api.events.game;
 
-import org.bukkit.Location;
 import org.bukkit.entity.Player;
-import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.Nullable;
 import plugily.projects.minigamesbox.api.events.PlugilyEvent;
 import plugily.projects.murdermystery.arena.Arena;
 
-/**
- * @author Tigerpanzer_02
- * <p>
- * Created at 15.04.2022
- */
-public class MurderGameCorpseSpawnEvent extends PlugilyEvent implements Cancellable {
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class MurderGameStartEvent extends PlugilyEvent {
 
   private static final HandlerList HANDLERS = new HandlerList();
-  private boolean isCancelled = false;
-  private final Player player;
-  private final Location location;
-  private final Player killer;
+  private final List<Player> players;
 
-  public MurderGameCorpseSpawnEvent(Arena arena, Player player, Location location) {
-    this(arena, player, location, null);
-  }
-
-  public MurderGameCorpseSpawnEvent(Arena arena, Player player, Location location, @Nullable Player killer) {
+  public MurderGameStartEvent(Arena arena, List<Player> players) {
     super(arena);
-    this.player = player;
-    this.location = location;
-    this.killer = killer;
+    this.players = Collections.unmodifiableList(new ArrayList<>(players));
   }
 
   public static HandlerList getHandlerList() {
@@ -59,27 +46,7 @@ public class MurderGameCorpseSpawnEvent extends PlugilyEvent implements Cancella
     return HANDLERS;
   }
 
-  @Override
-  public boolean isCancelled() {
-    return isCancelled;
+  public List<Player> getPlayers() {
+    return players;
   }
-
-  @Override
-  public void setCancelled(boolean cancelled) {
-    isCancelled = cancelled;
-  }
-
-  public Player getPlayer() {
-    return player;
-  }
-
-  public Location getLocation() {
-    return location;
-  }
-
-  @Nullable
-  public Player getKiller() {
-    return killer;
-  }
-
 }

--- a/src/main/java/plugily/projects/murdermystery/arena/ArenaEvents.java
+++ b/src/main/java/plugily/projects/murdermystery/arena/ArenaEvents.java
@@ -55,6 +55,9 @@ import plugily.projects.minigamesbox.classic.utils.version.xseries.XPotion;
 import plugily.projects.minigamesbox.classic.utils.version.xseries.XSound;
 import plugily.projects.minigamesbox.classic.utils.version.xseries.inventory.XInventoryView;
 import plugily.projects.murdermystery.Main;
+import plugily.projects.murdermystery.api.events.game.MurderGameGetBowEvent;
+import plugily.projects.murdermystery.api.events.game.MurderGameGoldPickupEvent;
+import plugily.projects.murdermystery.api.events.game.MurderGamePowerUpPickupEvent;
 import plugily.projects.murdermystery.arena.managers.MapRestorerManager;
 import plugily.projects.murdermystery.arena.role.Role;
 import plugily.projects.murdermystery.arena.special.pray.PrayerRegistry;
@@ -132,6 +135,12 @@ public class ArenaEvents extends PluginArenaEvents {
     if(arena.getBowHologram() != null
       && e.getItem().equals(arena.getBowHologram().getEntityItem())) {
       if(!user.isSpectator() && Role.isRole(Role.INNOCENT, user, arena)) {
+        MurderGameGetBowEvent murderGameGetBowEvent = new MurderGameGetBowEvent(arena, player);
+        Bukkit.getPluginManager().callEvent(murderGameGetBowEvent);
+        if(murderGameGetBowEvent.isCancelled()) {
+          return;
+        }
+
         XSound.BLOCK_LAVA_POP.play(player.getLocation(), 1F, 2F);
 
         ((MapRestorerManager) arena.getMapRestorerManager()).removeBowHolo();
@@ -154,6 +163,10 @@ public class ArenaEvents extends PluginArenaEvents {
     }
 
     if(e.getItem().getItemStack().getType() != Material.GOLD_INGOT) {
+      if(!user.isSpectator() && arena.getArenaState() == IArenaState.IN_GAME) {
+        MurderGamePowerUpPickupEvent murderGamePowerUpPickupEvent = new MurderGamePowerUpPickupEvent(arena, player, e.getItem().getItemStack());
+        Bukkit.getPluginManager().callEvent(murderGamePowerUpPickupEvent);
+      }
       return;
     }
 
@@ -166,16 +179,22 @@ public class ArenaEvents extends PluginArenaEvents {
       return;
     }
 
+    int pickedUpAmount = e.getItem().getItemStack().getAmount();
+    if(PrayerRegistry.getRush().contains(player)) {
+      pickedUpAmount = 3 * pickedUpAmount;
+    }
+    MurderGameGoldPickupEvent murderGameGoldPickupEvent = new MurderGameGoldPickupEvent(arena, player, pickedUpAmount);
+    Bukkit.getPluginManager().callEvent(murderGameGoldPickupEvent);
+    if(murderGameGoldPickupEvent.isCancelled()) {
+      return;
+    }
+
     e.getItem().remove();
 
     XSound.BLOCK_LAVA_POP.play(player.getLocation(), 1, 1);
     arena.getGoldSpawned().remove(e.getItem());
 
-    ItemStack stack = new ItemStack(Material.GOLD_INGOT, e.getItem().getItemStack().getAmount());
-    if(PrayerRegistry.getRush().contains(player)) {
-      stack.setAmount(3 * e.getItem().getItemStack().getAmount());
-    }
-
+    ItemStack stack = new ItemStack(Material.GOLD_INGOT, murderGameGoldPickupEvent.getAmount());
     ItemPosition.addItem(user, ItemPosition.GOLD_INGOTS, stack);
     user.adjustStatistic("LOCAL_GOLD", stack.getAmount());
     ArenaUtils.addScore(user, ArenaUtils.ScoreAction.GOLD_PICKUP, stack.getAmount());
@@ -189,6 +208,12 @@ public class ArenaEvents extends PluginArenaEvents {
     }
 
     if(user.getStatistic("LOCAL_GOLD") >= plugin.getConfig().getInt("Gold.Amount.Bow", 10)) {
+      MurderGameGetBowEvent murderGameGetBowEvent = new MurderGameGetBowEvent(arena, player);
+      Bukkit.getPluginManager().callEvent(murderGameGetBowEvent);
+      if(murderGameGetBowEvent.isCancelled()) {
+        return;
+      }
+
       user.setStatistic("LOCAL_GOLD", 0);
       new TitleBuilder("IN_GAME_MESSAGES_ARENA_PLAYING_BOW_SHOT_TITLE")
         .asKey()
@@ -369,7 +394,7 @@ public class ArenaEvents extends PluginArenaEvents {
     ComplementAccessor.getComplement().setDeathMessage(e, "");
     e.getDrops().clear();
     e.setDroppedExp(0);
-    plugin.getCorpseHandler().spawnCorpse(player, arena);
+    plugin.getCorpseHandler().spawnCorpse(player, arena, player.getKiller());
     XPotion.BLINDNESS.buildPotionEffect(3 * 20, 1).apply(player);
     if(arena.getArenaState() == IArenaState.STARTING) {
       return;

--- a/src/main/java/plugily/projects/murdermystery/arena/ArenaManager.java
+++ b/src/main/java/plugily/projects/murdermystery/arena/ArenaManager.java
@@ -18,6 +18,7 @@
 
 package plugily.projects.murdermystery.arena;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import plugily.projects.minigamesbox.api.arena.IArenaState;
@@ -29,6 +30,7 @@ import plugily.projects.minigamesbox.classic.handlers.language.TitleBuilder;
 import plugily.projects.minigamesbox.classic.utils.actionbar.ActionBar;
 import plugily.projects.minigamesbox.classic.utils.version.VersionUtils;
 import plugily.projects.murdermystery.Main;
+import plugily.projects.murdermystery.api.events.game.MurderGameEndEvent;
 import plugily.projects.murdermystery.arena.managers.MapRestorerManager;
 import plugily.projects.murdermystery.arena.role.Role;
 import plugily.projects.murdermystery.arena.special.SpecialBlock;
@@ -135,6 +137,7 @@ public class ArenaManager extends PluginArenaManager {
     if(pluginArena == null) {
       return;
     }
+    Bukkit.getPluginManager().callEvent(new MurderGameEndEvent(pluginArena, new ArrayList<>(arena.getPlayers())));
     for(SpecialBlock specialBlock : pluginArena.getSpecialBlocks()) {
       if(specialBlock.getArmorStandHologram() != null) {
         specialBlock.getArmorStandHologram().delete();

--- a/src/main/java/plugily/projects/murdermystery/arena/special/SpecialBlockEvents.java
+++ b/src/main/java/plugily/projects/murdermystery/arena/special/SpecialBlockEvents.java
@@ -36,6 +36,7 @@ import plugily.projects.minigamesbox.classic.utils.version.ServerVersion;
 import plugily.projects.minigamesbox.classic.utils.version.VersionUtils;
 import plugily.projects.minigamesbox.classic.utils.version.xseries.XMaterial;
 import plugily.projects.murdermystery.Main;
+import plugily.projects.murdermystery.api.events.game.MurderGameBuyEvent;
 import plugily.projects.murdermystery.arena.Arena;
 import plugily.projects.murdermystery.arena.special.mysterypotion.MysteryPotion;
 import plugily.projects.murdermystery.arena.special.mysterypotion.MysteryPotionRegistry;
@@ -117,6 +118,15 @@ public class SpecialBlockEvents implements Listener {
     }
 
     org.bukkit.Location blockLoc = event.getClickedBlock().getLocation();
+    Arena arena = plugin.getArenaRegistry().getArena(event.getPlayer());
+    if(arena == null) {
+      return;
+    }
+    MurderGameBuyEvent murderGameBuyEvent = new MurderGameBuyEvent(arena, event.getPlayer(), SpecialBlock.SpecialBlockType.MYSTERY_CAULDRON, 1);
+    Bukkit.getPluginManager().callEvent(murderGameBuyEvent);
+    if(murderGameBuyEvent.isCancelled()) {
+      return;
+    }
 
     VersionUtils.sendParticles("FIREWORKS_SPARK", event.getPlayer(), blockLoc, 10);
     Item item = blockLoc.getWorld().dropItemNaturally(blockLoc.clone().add(0, 1, 0), new ItemStack(Material.POTION, 1));
@@ -141,6 +151,16 @@ public class SpecialBlockEvents implements Listener {
       new MessageBuilder("IN_GAME_MESSAGES_ARENA_PLAYING_SPECIAL_BLOCKS_NOT_ENOUGH_GOLD").asKey().player(event.getPlayer()).integer(1).sendPlayer();
       return;
     }
+    Arena arena = plugin.getArenaRegistry().getArena(event.getPlayer());
+    if(arena == null) {
+      return;
+    }
+    MurderGameBuyEvent murderGameBuyEvent = new MurderGameBuyEvent(arena, event.getPlayer(), SpecialBlock.SpecialBlockType.PRAISE_DEVELOPER, 1);
+    Bukkit.getPluginManager().callEvent(murderGameBuyEvent);
+    if(murderGameBuyEvent.isCancelled()) {
+      return;
+    }
+
     new MessageBuilder("IN_GAME_MESSAGES_ARENA_PLAYING_SPECIAL_BLOCKS_PRAY_CHAT").asKey().player(event.getPlayer()).sendPlayer();
     user.adjustStatistic("LOCAL_PRAISES", 1);
     VersionUtils.sendParticles("FIREWORKS_SPARK", event.getPlayer(), event.getClickedBlock().getLocation(), 10);

--- a/src/main/java/plugily/projects/murdermystery/arena/states/InGameState.java
+++ b/src/main/java/plugily/projects/murdermystery/arena/states/InGameState.java
@@ -18,6 +18,7 @@
 
 package plugily.projects.murdermystery.arena.states;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
@@ -31,6 +32,7 @@ import plugily.projects.minigamesbox.classic.handlers.language.MessageBuilder;
 import plugily.projects.minigamesbox.classic.handlers.language.TitleBuilder;
 import plugily.projects.minigamesbox.classic.utils.version.xseries.XMaterial;
 import plugily.projects.minigamesbox.classic.utils.version.xseries.XSound;
+import plugily.projects.murdermystery.api.events.game.MurderGameGoldSpawnEvent;
 import plugily.projects.murdermystery.arena.Arena;
 import plugily.projects.murdermystery.arena.ArenaUtils;
 import plugily.projects.murdermystery.arena.role.Role;
@@ -166,7 +168,14 @@ public class InGameState extends PluginInGameState {
         }
       }
     }
-    arena.getGoldSpawned().add(location.getWorld().dropItem(location, new ItemStack(Material.GOLD_INGOT, 1)));
-    getPlugin().getPowerupRegistry().spawnPowerup(location, arena);
+    MurderGameGoldSpawnEvent murderGameGoldSpawnEvent = new MurderGameGoldSpawnEvent(arena, location.clone());
+    Bukkit.getPluginManager().callEvent(murderGameGoldSpawnEvent);
+    if(murderGameGoldSpawnEvent.isCancelled()) {
+      return;
+    }
+
+    Location dropLocation = murderGameGoldSpawnEvent.getLocation();
+    arena.getGoldSpawned().add(dropLocation.getWorld().dropItem(dropLocation, new ItemStack(Material.GOLD_INGOT, 1)));
+    getPlugin().getPowerupRegistry().spawnPowerup(dropLocation, arena);
   }
 }

--- a/src/main/java/plugily/projects/murdermystery/arena/states/StartingState.java
+++ b/src/main/java/plugily/projects/murdermystery/arena/states/StartingState.java
@@ -30,6 +30,7 @@ import plugily.projects.minigamesbox.classic.handlers.language.MessageBuilder;
 import plugily.projects.minigamesbox.classic.handlers.language.TitleBuilder;
 import plugily.projects.minigamesbox.classic.utils.actionbar.ActionBar;
 import plugily.projects.minigamesbox.classic.utils.version.VersionUtils;
+import plugily.projects.murdermystery.api.events.game.MurderGameStartEvent;
 import plugily.projects.murdermystery.arena.Arena;
 import plugily.projects.murdermystery.arena.ArenaUtils;
 import plugily.projects.murdermystery.arena.role.Role;
@@ -90,6 +91,7 @@ public class StartingState extends PluginStartingState {
 
       // Load and append special blocks hologram
       pluginArena.getSpecialBlocks().forEach(pluginArena::loadSpecialBlock);
+      Bukkit.getPluginManager().callEvent(new MurderGameStartEvent(pluginArena, new ArrayList<>(arena.getPlayers())));
     }
   }
 

--- a/src/main/java/plugily/projects/murdermystery/handlers/CorpseHandler.java
+++ b/src/main/java/plugily/projects/murdermystery/handlers/CorpseHandler.java
@@ -26,6 +26,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.util.EulerAngle;
+import org.jetbrains.annotations.Nullable;
 import org.golde.bukkit.corpsereborn.CorpseAPI.CorpseAPI;
 import org.golde.bukkit.corpsereborn.CorpseAPI.events.CorpseClickEvent;
 import org.golde.bukkit.corpsereborn.CorpseAPI.events.CorpseSpawnEvent;
@@ -75,7 +76,12 @@ public class CorpseHandler implements Listener {
 
   @SuppressWarnings("deprecation")
   public void spawnCorpse(Player player, Arena arena) {
-    MurderGameCorpseSpawnEvent murderGameCorpseSpawnEvent = new MurderGameCorpseSpawnEvent(arena, player.getPlayer(), player.getLocation());
+    spawnCorpse(player, arena, null);
+  }
+
+  @SuppressWarnings("deprecation")
+  public void spawnCorpse(Player player, Arena arena, @Nullable Player killer) {
+    MurderGameCorpseSpawnEvent murderGameCorpseSpawnEvent = new MurderGameCorpseSpawnEvent(arena, player.getPlayer(), player.getLocation(), killer);
     Bukkit.getPluginManager().callEvent(murderGameCorpseSpawnEvent);
     if(murderGameCorpseSpawnEvent.isCancelled()) {
       return;


### PR DESCRIPTION
Comes with the following new Events:
- MurderGameStartEvent
- MurderGameEndEvent
- MurderGamePowerUpPickupEvent
- MurderGameGoldSpawnEvent
- MurderGameGoldPickupEvent
- MurderGameGetBowEvent
- MurderGameBuyEvent

Also enhanced the current one:
- In MurderGameCorpseSpawnEvent add who the killer is

Tested on Paper on MC version 26.1.2
